### PR TITLE
Lock the Clap beta version to beta 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ msrv = "1.45.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.0-beta.4"
+clap = "=3.0.0-beta.4"
 anyhow = "1.0.44"
 chrono = "0.4.15"
 guppy = "0.10.1"


### PR DESCRIPTION
Cargo's version resolution would use the latest pre-release version prior to this change. If Clap releases a breaking change in the pre-release version, it would also break our build. This commit fixes the issue by locking the beta to a specific version.

See also #18 